### PR TITLE
Java integration of new formats in the web component

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,7 @@ vcf-month-picker-flow/.vscode/.copilot-plugin
 .classpath
 .project
 .idea
+/vcf-month-picker-flow-demo/tsconfig.json
+/vcf-month-picker-flow-demo/types.d.ts
+/vcf-month-picker-flow-demo/vite.config.ts
+/vcf-month-picker-flow-demo/vite.generated.ts

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.vaadin.addons.componentfactory</groupId>
     <artifactId>vcf-month-picker-flow-parent</artifactId>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>1.1.0</version>
     <packaging>pom</packaging>
     <name>Month Picker Parent</name>
 

--- a/vcf-month-picker-flow-demo/pom.xml
+++ b/vcf-month-picker-flow-demo/pom.xml
@@ -9,7 +9,7 @@
     <packaging>war</packaging>
     <name>Month Picker Add-on Demo</name>
 
-    <version>1.0.1-SNAPSHOT</version>
+    <version>1.1.0</version>
     <inceptionYear>2025</inceptionYear>
     <organization>
         <name>Vaadin Ltd</name>

--- a/vcf-month-picker-flow-demo/src/main/java/org/vaadin/addons/componentfactory/demo/MonthPickerDemoView.java
+++ b/vcf-month-picker-flow-demo/src/main/java/org/vaadin/addons/componentfactory/demo/MonthPickerDemoView.java
@@ -13,14 +13,17 @@
  */
 package org.vaadin.addons.componentfactory.demo;
 
+import java.time.Month;
+import java.time.YearMonth;
+import java.time.format.TextStyle;
+import java.util.Arrays;
+import java.util.Locale;
+import org.vaadin.addons.componentfactory.monthpicker.MonthPicker;
+import org.vaadin.addons.componentfactory.monthpicker.MonthPicker.MonthPickerI18n;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.demo.DemoView;
 import com.vaadin.flow.router.Route;
-import java.time.YearMonth;
-import java.util.Arrays;
-import org.vaadin.addons.componentfactory.monthpicker.MonthPicker;
-import org.vaadin.addons.componentfactory.monthpicker.MonthPicker.MonthPickerI18n;
 
 /**
  * View for {@link MonthPicker} demo.
@@ -39,6 +42,9 @@ public class MonthPickerDemoView extends DemoView {
     createInvalidValueMonthPickerDemo();
     createReadOnlyAndDisabledDemo();
     createInternalizedMonthPickerDemo();
+    createAlternativeFormatsTwoDigitYearDemo();
+    createAlternativeFormatsShortMonthNamesDemo();
+    createAlternativeFormatsFullMonthNamesDemo();
 
     addCard("Additional code used in the demo", new Span("These methods are used in the demo."));
   }
@@ -179,6 +185,147 @@ public class MonthPickerDemoView extends DemoView {
     monthPicker.setId("internalized-month-picker");
 
     addCard("With Custom Months and Formats", monthPicker, message);
+  }
+
+  private void createAlternativeFormatsTwoDigitYearDemo() {
+    Div message = createMessageDiv("alternative-formats-2-digit-year-demo-message");
+
+    // begin-source-example
+    // source-example-heading: Alternative Formats - 2-digit years
+    MonthPicker shortYearMonthPicker = new MonthPicker();
+    shortYearMonthPicker.setLabel("Short Year Month Picker");
+    shortYearMonthPicker.setPlaceholder("Select a month");
+    shortYearMonthPicker.setClearButtonVisible(true);
+
+    MonthPickerI18n i18n = new MonthPickerI18n();
+    i18n.setFormats("MM.YY", "MM/YY", "MMYY", "MM-YY", "YY.MM", "MM YY");
+
+    i18n.setMonthNames(
+            Arrays.asList(Arrays.stream(Month.values())
+                    .map(m -> m.getDisplayName(TextStyle.FULL, Locale.ENGLISH))
+                    .toArray(String[]::new))
+    );
+    i18n.setMonthLabels(
+            Arrays.asList(Arrays.stream(Month.values())
+                    .map(m -> m.getDisplayName(TextStyle.SHORT, Locale.ENGLISH))
+                    .toArray(String[]::new))
+    );
+
+    shortYearMonthPicker.seti18n(i18n);
+    shortYearMonthPicker.setHelperText(
+            "2-digit year formats: 'MM.YY', 'MM/YY', 'MMYY', 'MM-YY', 'YY.MM', 'MM YY'");
+
+    shortYearMonthPicker.addValueChangeListener(ev -> {
+      updateMessage(message, shortYearMonthPicker);
+    });
+    // end-source-example
+
+    shortYearMonthPicker.setId("alternative-formats-2-digit-year");
+
+    addCard("Alternative Formats - 2-digit years", shortYearMonthPicker, message);
+  }
+
+  private void createAlternativeFormatsShortMonthNamesDemo() {
+    Div message = createMessageDiv("alternative-formats-short-month-names-demo-message");
+
+    // begin-source-example
+    // source-example-heading: Alternative Formats - Short month names
+
+    // This month picker formats and parses picked values as the short month name, for instance "Jan". This format
+    // can be combined with all other formats, to allow also entering months by numbers, for instance "01", that then
+    // will be translated to "Jan".
+    MonthPicker shortMonthNamePicker = new MonthPicker();
+    shortMonthNamePicker.setLabel("Short Month Name Picker");
+    shortMonthNamePicker.setPlaceholder("Select a month");
+    shortMonthNamePicker.setClearButtonVisible(true);
+
+    MonthPickerI18n shortMonthNameI18n = new MonthPickerI18n();
+    shortMonthNameI18n.setFormats("MMM.YYYY",
+            // additional short month names
+            "MMM/YYYY", "MMMYYYY", "MMM-YYYY", "YYYY.MMM", "MMM YYYY",
+            // matching numeric formats to allow usual input
+            "MM.YYYY", "MM/YYYY", "MMYYYY", "MM-YYYY", "YYYY.MM", "MM YYYY"
+    );
+
+    // This i18n setting is needed, when short month name parsing and formatting is used.
+    shortMonthNameI18n.setShortMonthNames(
+            Arrays.asList(Arrays.stream(Month.values())
+                    .map(m -> m.getDisplayName(TextStyle.FULL, Locale.ENGLISH))
+                    .toArray(String[]::new))
+    );
+
+
+    shortMonthNameI18n.setMonthNames(
+            Arrays.asList(Arrays.stream(Month.values())
+                    .map(m -> m.getDisplayName(TextStyle.FULL, Locale.ENGLISH))
+                    .toArray(String[]::new))
+    );
+    shortMonthNameI18n.setMonthLabels(
+            Arrays.asList(Arrays.stream(Month.values())
+                    .map(m -> m.getDisplayName(TextStyle.SHORT, Locale.ENGLISH))
+                    .toArray(String[]::new))
+    );
+
+    shortMonthNamePicker.seti18n(shortMonthNameI18n);
+    shortMonthNamePicker.setHelperText(
+            "Short month name formats: 'MMM.YYYY', 'MMM/YYYY', 'MMMYYYY','MMM.YYYY', 'MMM/YYYY', 'MMM YYYY'");
+
+    shortMonthNamePicker.addValueChangeListener(ev -> {
+      updateMessage(message, shortMonthNamePicker);
+    });
+
+    // end-source-example
+
+    shortMonthNamePicker.setId("alternative-formats-short-month-names");
+
+    addCard("Alternative Formats - Short month names", shortMonthNamePicker, message);
+  }
+
+  private void createAlternativeFormatsFullMonthNamesDemo() {
+    Div message = createMessageDiv("alternative-formats-full-month-names-demo-message");
+
+    // begin-source-example
+    // source-example-heading: Alternative Formats - Month names
+
+    // This month picker formats and parses picked values as the full month name, for instance "January". This format
+    // can be combined with all other formats, to allow also entering months by numbers, for instance "01", that then
+    // will be translated to "January".
+    MonthPicker fullMonthNamePicker = new MonthPicker();
+    fullMonthNamePicker.setLabel("Full Month Name Picker");
+    fullMonthNamePicker.setPlaceholder("Select a month");
+    fullMonthNamePicker.setClearButtonVisible(true);
+
+    MonthPickerI18n fullMonthNameI18n = new MonthPickerI18n();
+    fullMonthNameI18n.setFormats("MMMM.YYYY",
+            // additional short month names
+            "MMMM/YYYY", "MMMMYYYY", "MMMM-YYYY", "YYYY.MMMM", "MMMM YYYY",
+            // matching numeric formats to allow usual input
+            "MM.YYYY", "MM/YYYY", "MMYYYY", "MM-YYYY", "YYYY.MM", "MM YYYY"
+    );
+    fullMonthNameI18n.setMonthNames(
+            Arrays.asList(Arrays.stream(Month.values())
+                    .map(m -> m.getDisplayName(TextStyle.FULL, Locale.ENGLISH))
+                    .toArray(String[]::new))
+    );
+    fullMonthNameI18n.setMonthLabels(
+            Arrays.asList(Arrays.stream(Month.values())
+                    .map(m -> m.getDisplayName(TextStyle.SHORT, Locale.ENGLISH))
+                    .toArray(String[]::new))
+    );
+
+    fullMonthNamePicker.seti18n(fullMonthNameI18n);
+    fullMonthNamePicker.setHelperText(
+            "Full month name formats: 'MMMM.YYYY', 'MMMM/YYYY', 'MMMMYYYY','MMMM.YYYY', 'MMMM/YYYY', 'MMMM YYYY'");
+
+    fullMonthNamePicker.addValueChangeListener(ev -> {
+      updateMessage(message, fullMonthNamePicker);
+    });
+
+    // end-source-example
+
+    fullMonthNamePicker.setId("alternative-formats-full-month-names");
+
+    addCard("Alternative Formats - Full month names", fullMonthNamePicker, message);
   }
 
   // begin-source-example

--- a/vcf-month-picker-flow-demo/src/main/java/org/vaadin/addons/componentfactory/demo/MonthPickerDemoView.java
+++ b/vcf-month-picker-flow-demo/src/main/java/org/vaadin/addons/componentfactory/demo/MonthPickerDemoView.java
@@ -240,9 +240,9 @@ public class MonthPickerDemoView extends DemoView {
     shortMonthNamePicker.setClearButtonVisible(true);
 
     MonthPickerI18n shortMonthNameI18n = new MonthPickerI18n();
-    shortMonthNameI18n.setFormats("MMM.YYYY",
+    shortMonthNameI18n.setFormats("MMM YYYY",
             // additional short month names
-            "MMM/YYYY", "MMMYYYY", "MMM-YYYY", "YYYY.MMM", "MMM YYYY",
+            "MMM.YYYY", "MMM/YYYY", "MMMYYYY", "MMM-YYYY", "YYYY.MMM", "MMM YYYY",
             // matching numeric formats to allow usual input
             "MM.YYYY", "MM/YYYY", "MMYYYY", "MM-YYYY", "YYYY.MM", "MM YYYY"
     );
@@ -251,6 +251,7 @@ public class MonthPickerDemoView extends DemoView {
     shortMonthNameI18n.setShortMonthNames(
             Arrays.asList(Arrays.stream(Month.values())
                     .map(m -> m.getDisplayName(TextStyle.FULL, Locale.ENGLISH))
+                    .map(s -> s.substring(0, 3))
                     .toArray(String[]::new))
     );
 
@@ -268,7 +269,7 @@ public class MonthPickerDemoView extends DemoView {
 
     shortMonthNamePicker.seti18n(shortMonthNameI18n);
     shortMonthNamePicker.setHelperText(
-            "Short month name formats: 'MMM.YYYY', 'MMM/YYYY', 'MMMYYYY','MMM.YYYY', 'MMM/YYYY', 'MMM YYYY'");
+            "Short month name formats: 'MMM YYYY', 'MMM.YYYY', 'MMM/YYYY', 'MMMYYYY','MMM.YYYY', 'MMM/YYYY', 'MMM YYYY'");
 
     shortMonthNamePicker.addValueChangeListener(ev -> {
       updateMessage(message, shortMonthNamePicker);
@@ -296,9 +297,9 @@ public class MonthPickerDemoView extends DemoView {
     fullMonthNamePicker.setClearButtonVisible(true);
 
     MonthPickerI18n fullMonthNameI18n = new MonthPickerI18n();
-    fullMonthNameI18n.setFormats("MMMM.YYYY",
+    fullMonthNameI18n.setFormats("MMMM YYYY",
             // additional short month names
-            "MMMM/YYYY", "MMMMYYYY", "MMMM-YYYY", "YYYY.MMMM", "MMMM YYYY",
+            "MMMM.YYYY","MMMM/YYYY", "MMMMYYYY", "MMMM-YYYY", "YYYY.MMMM", "MMMM YYYY",
             // matching numeric formats to allow usual input
             "MM.YYYY", "MM/YYYY", "MMYYYY", "MM-YYYY", "YYYY.MM", "MM YYYY"
     );
@@ -315,7 +316,7 @@ public class MonthPickerDemoView extends DemoView {
 
     fullMonthNamePicker.seti18n(fullMonthNameI18n);
     fullMonthNamePicker.setHelperText(
-            "Full month name formats: 'MMMM.YYYY', 'MMMM/YYYY', 'MMMMYYYY','MMMM.YYYY', 'MMMM/YYYY', 'MMMM YYYY'");
+            "Full month name formats: 'MMMM YYYY', 'MMMM.YYYY', 'MMMM/YYYY', 'MMMMYYYY','MMMM.YYYY', 'MMMM/YYYY', 'MMMM YYYY'");
 
     fullMonthNamePicker.addValueChangeListener(ev -> {
       updateMessage(message, fullMonthNamePicker);

--- a/vcf-month-picker-flow/pom.xml
+++ b/vcf-month-picker-flow/pom.xml
@@ -10,7 +10,7 @@
 
     <name>Month Picker Add-on</name>
 
-    <version>1.0.1-SNAPSHOT</version>
+    <version>1.1.0</version>
     <inceptionYear>2025</inceptionYear>
     <organization>
         <name>Vaadin Ltd</name>

--- a/vcf-month-picker-flow/src/main/java/org/vaadin/addons/componentfactory/monthpicker/MonthPicker.java
+++ b/vcf-month-picker-flow/src/main/java/org/vaadin/addons/componentfactory/monthpicker/MonthPicker.java
@@ -287,6 +287,15 @@ public class MonthPicker extends AbstractSinglePropertyField<MonthPicker, YearMo
 
     /**
      * Sets a single format pattern to be used for both displaying and parsing values.
+     * <p/>
+     * <ul>
+     *   <li>{@code YY} - 2-digit year</li>
+     *   <li>{@code YYYY} - 4-digit year</li>
+     *   <li>{@code M} - 1- or 2-digit month</li>
+     *   <li>{@code MM} - 2-digit month (with leading zero)</li>
+     *   <li>{@code MMM} - short month name (requires the i18n short month names to be set)</li>
+     *   <li>{@code MMMM} - long month name (requires the i18n month names to be set)</li>
+     * </ul>
      *
      * @param format a string pattern using year-month symbols (e.g., {@code "MM-YYYY"})
      * @return this instance for method chaining
@@ -306,10 +315,14 @@ public class MonthPicker extends AbstractSinglePropertyField<MonthPicker, YearMo
      *
      * <p>Format patterns may include:
      * <ul>
+     *   <li>{@code YY} - 2-digit year</li>
      *   <li>{@code YYYY} - 4-digit year</li>
      *   <li>{@code M} - 1- or 2-digit month</li>
      *   <li>{@code MM} - 2-digit month (with leading zero)</li>
+     *   <li>{@code MMM} - short month name (requires the i18n short month names to be set)</li>
+     *   <li>{@code MMMM} - long month name (requires the i18n month names to be set)</li>
      * </ul>
+     * </p>
      *
      * @param primaryFormat the main format used for formatting and parsing
      * @param additionalParsingFormats fallback formats used for parsing only

--- a/vcf-month-picker-flow/src/main/java/org/vaadin/addons/componentfactory/monthpicker/MonthPicker.java
+++ b/vcf-month-picker-flow/src/main/java/org/vaadin/addons/componentfactory/monthpicker/MonthPicker.java
@@ -13,27 +13,6 @@
  */
 package org.vaadin.addons.componentfactory.monthpicker;
 
-import com.vaadin.flow.component.AbstractSinglePropertyField;
-import com.vaadin.flow.component.ComponentEvent;
-import com.vaadin.flow.component.ComponentEventListener;
-import com.vaadin.flow.component.DomEvent;
-import com.vaadin.flow.component.Focusable;
-import com.vaadin.flow.component.HasHelper;
-import com.vaadin.flow.component.HasLabel;
-import com.vaadin.flow.component.HasPlaceholder;
-import com.vaadin.flow.component.HasValidation;
-import com.vaadin.flow.component.Synchronize;
-import com.vaadin.flow.component.Tag;
-import com.vaadin.flow.component.dependency.JsModule;
-import com.vaadin.flow.component.dependency.NpmPackage;
-import com.vaadin.flow.component.shared.HasAutoOpen;
-import com.vaadin.flow.component.shared.HasClearButton;
-import com.vaadin.flow.component.shared.HasTooltip;
-import com.vaadin.flow.function.SerializableFunction;
-import com.vaadin.flow.shared.Registration;
-import elemental.json.Json;
-import elemental.json.JsonArray;
-import elemental.json.JsonObject;
 import java.io.Serializable;
 import java.time.YearMonth;
 import java.util.ArrayList;
@@ -42,6 +21,16 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import com.vaadin.flow.component.*;
+import com.vaadin.flow.component.dependency.JsModule;
+import com.vaadin.flow.component.shared.HasAutoOpen;
+import com.vaadin.flow.component.shared.HasClearButton;
+import com.vaadin.flow.component.shared.HasTooltip;
+import com.vaadin.flow.function.SerializableFunction;
+import com.vaadin.flow.shared.Registration;
+import elemental.json.Json;
+import elemental.json.JsonArray;
+import elemental.json.JsonObject;
 
 
 /**
@@ -56,12 +45,13 @@ import java.util.stream.Stream;
  * displaying the selected year-month.
  * </p>
  * 
- * @see MonthPicker.MonthPickerI18n
+ * @see MonthPickerI18n
  */
 @SuppressWarnings("serial")
 @Tag("vcf-month-picker")
-@NpmPackage(value = "@vaadin-component-factory/vcf-month-picker", version = "1.0.0")
-@JsModule("@vaadin-component-factory/vcf-month-picker/dist/src/vcf-month-picker.js")
+//@NpmPackage(value = "@vaadin-component-factory/vcf-month-picker", version = "1.0.0")
+//@JsModule("@vaadin-component-factory/vcf-month-picker/dist/src/vcf-month-picker.js")
+@JsModule("./src/month/vcf-month-picker.ts")
 public class MonthPicker extends AbstractSinglePropertyField<MonthPicker, YearMonth>
     implements HasLabel, HasAutoOpen, HasClearButton, HasPlaceholder, HasHelper, HasValidation,
     HasTooltip, Focusable<MonthPicker> {
@@ -184,6 +174,15 @@ public class MonthPicker extends AbstractSinglePropertyField<MonthPicker, YearMo
       i18nJson.put("monthNames", monthNames);
     }
 
+    // short month names (used for MMM parsing)
+    JsonArray shortMonthNames = Json.createArray();
+    if (i18n.getShortMonthNames() != null) {
+      for (int i = 0; i < i18n.getShortMonthNames().size(); i++) {
+        shortMonthNames.set(i, i18n.getShortMonthNames().get(i));
+      }
+      i18nJson.put("shortMonthNames", shortMonthNames);
+    }
+
     // monthLabels
     JsonArray monthLabels = Json.createArray();
     if (i18n.getMonthLabels() != null) {
@@ -214,6 +213,7 @@ public class MonthPicker extends AbstractSinglePropertyField<MonthPicker, YearMo
   public static class MonthPickerI18n implements Serializable {
     private List<String> monthNames;
     private List<String> monthLabels;
+    private List<String> shortMonthNames;
     private List<String> formats;
 
     /**
@@ -226,7 +226,9 @@ public class MonthPicker extends AbstractSinglePropertyField<MonthPicker, YearMo
     }
 
     /**
-     * Sets the name of the months, starting from January and ending on December.
+     * Sets the name of the months, starting from January and ending on December. These are used for parsing and
+     * formatting, when the short month name pattern ("MMM") is used.
+     *
      *
      * @param monthNames the month names
      * @return this instance for method chaining
@@ -253,6 +255,27 @@ public class MonthPicker extends AbstractSinglePropertyField<MonthPicker, YearMo
      */
     public MonthPickerI18n setMonthLabels(List<String> monthLabels) {
       this.monthLabels = monthLabels;
+      return this;
+    }
+
+    /**
+     * Gets the short labels of the months.
+     *
+     * @return the short month labels
+     */
+    public List<String> getShortMonthNames() {
+      return shortMonthNames;
+    }
+
+    /**
+     * Sets the short names of the months. These are used for parsing and formatting, when the short month
+     * name pattern ("MMM") is used.
+     *
+     * @param shortMonthNames the short month names
+     * @return this instance for method chaining
+     */
+    public MonthPickerI18n setShortMonthNames(List<String> shortMonthNames) {
+      this.shortMonthNames = shortMonthNames;
       return this;
     }
 

--- a/vcf-month-picker-flow/src/main/java/org/vaadin/addons/componentfactory/monthpicker/MonthPicker.java
+++ b/vcf-month-picker-flow/src/main/java/org/vaadin/addons/componentfactory/monthpicker/MonthPicker.java
@@ -23,6 +23,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import com.vaadin.flow.component.*;
 import com.vaadin.flow.component.dependency.JsModule;
+import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.component.shared.HasAutoOpen;
 import com.vaadin.flow.component.shared.HasClearButton;
 import com.vaadin.flow.component.shared.HasTooltip;
@@ -31,6 +32,7 @@ import com.vaadin.flow.shared.Registration;
 import elemental.json.Json;
 import elemental.json.JsonArray;
 import elemental.json.JsonObject;
+import jakarta.annotation.Nullable;
 
 
 /**
@@ -49,9 +51,8 @@ import elemental.json.JsonObject;
  */
 @SuppressWarnings("serial")
 @Tag("vcf-month-picker")
-//@NpmPackage(value = "@vaadin-component-factory/vcf-month-picker", version = "1.0.0")
-//@JsModule("@vaadin-component-factory/vcf-month-picker/dist/src/vcf-month-picker.js")
-@JsModule("./src/month/vcf-month-picker.ts")
+@NpmPackage(value = "@vaadin-component-factory/vcf-month-picker", version = "1.0.0")
+@JsModule("@vaadin-component-factory/vcf-month-picker/dist/src/vcf-month-picker.js")
 public class MonthPicker extends AbstractSinglePropertyField<MonthPicker, YearMonth>
     implements HasLabel, HasAutoOpen, HasClearButton, HasPlaceholder, HasHelper, HasValidation,
     HasTooltip, Focusable<MonthPicker> {
@@ -166,42 +167,37 @@ public class MonthPicker extends AbstractSinglePropertyField<MonthPicker, YearMo
     JsonObject i18nJson = Json.createObject();
 
     // monthNames
-    JsonArray monthNames = Json.createArray();
-    if (i18n.getMonthNames() != null) {
-      for (int i = 0; i < i18n.getMonthNames().size(); i++) {
-        monthNames.set(i, i18n.getMonthNames().get(i));
-      }
-      i18nJson.put("monthNames", monthNames);
-    }
+    writeStringListAsJsonArray(i18n.getMonthNames(), i18nJson, "monthNames");
 
     // short month names (used for MMM parsing)
-    JsonArray shortMonthNames = Json.createArray();
-    if (i18n.getShortMonthNames() != null) {
-      for (int i = 0; i < i18n.getShortMonthNames().size(); i++) {
-        shortMonthNames.set(i, i18n.getShortMonthNames().get(i));
-      }
-      i18nJson.put("shortMonthNames", shortMonthNames);
-    }
+    writeStringListAsJsonArray(i18n.getShortMonthNames(), i18nJson, "shortMonthNames");
 
     // monthLabels
-    JsonArray monthLabels = Json.createArray();
-    if (i18n.getMonthLabels() != null) {
-      for (int i = 0; i < i18n.getMonthLabels().size(); i++) {
-        monthLabels.set(i, i18n.getMonthLabels().get(i));
-      }
-      i18nJson.put("monthLabels", monthLabels);
-    }
+    writeStringListAsJsonArray(i18n.getMonthLabels(), i18nJson, "monthLabels");
 
     // formats
-    JsonArray formats = Json.createArray();
-    if (i18n.getFormats() != null) {
-      for (int i = 0; i < i18n.getFormats().size(); i++) {
-        formats.set(i, i18n.getFormats().get(i));
-      }
-      i18nJson.put("formats", formats);
-    }
+    writeStringListAsJsonArray(i18n.getFormats(), i18nJson, "formats");
 
     return i18nJson;
+  }
+
+  /**
+   * Converts the given list of strings into a json array. That json array is then written into the given
+   * json object at the given json property.
+   * <p/>
+   * When passing null for the list parameter, the method is noop.
+   * @param stringList list of strings to convert
+   * @param jsonObject target json object
+   * @param jsonProperty target json object property
+   */
+  private static void writeStringListAsJsonArray(@Nullable List<String> stringList, JsonObject jsonObject, String jsonProperty) {
+    if (stringList != null) { // TODO might make sense to check for empty lists, too?
+      JsonArray monthNames = Json.createArray();
+      for (int i = 0; i < stringList.size(); i++) {
+        monthNames.set(i, stringList.get(i));
+      }
+      jsonObject.put(jsonProperty, monthNames);
+    }
   }
 
   /**

--- a/vcf-month-picker-flow/src/main/java/org/vaadin/addons/componentfactory/monthpicker/MonthPicker.java
+++ b/vcf-month-picker-flow/src/main/java/org/vaadin/addons/componentfactory/monthpicker/MonthPicker.java
@@ -51,7 +51,7 @@ import jakarta.annotation.Nullable;
  */
 @SuppressWarnings("serial")
 @Tag("vcf-month-picker")
-@NpmPackage(value = "@vaadin-component-factory/vcf-month-picker", version = "1.0.0")
+@NpmPackage(value = "@vaadin-component-factory/vcf-month-picker", version = "1.1.0")
 @JsModule("@vaadin-component-factory/vcf-month-picker/dist/src/vcf-month-picker.js")
 public class MonthPicker extends AbstractSinglePropertyField<MonthPicker, YearMonth>
     implements HasLabel, HasAutoOpen, HasClearButton, HasPlaceholder, HasHelper, HasValidation,

--- a/vcf-month-picker-flow/src/main/java/org/vaadin/addons/componentfactory/monthpicker/MonthPicker.java
+++ b/vcf-month-picker-flow/src/main/java/org/vaadin/addons/componentfactory/monthpicker/MonthPicker.java
@@ -223,7 +223,7 @@ public class MonthPicker extends AbstractSinglePropertyField<MonthPicker, YearMo
 
     /**
      * Sets the name of the months, starting from January and ending on December. These are used for parsing and
-     * formatting, when the short month name pattern ("MMM") is used.
+     * formatting, when the long month name pattern ("MMMM") is used.
      *
      *
      * @param monthNames the month names

--- a/vcf-month-picker-flow/src/main/java/org/vaadin/addons/componentfactory/monthpicker/MonthPicker.java
+++ b/vcf-month-picker-flow/src/main/java/org/vaadin/addons/componentfactory/monthpicker/MonthPicker.java
@@ -349,11 +349,11 @@ public class MonthPicker extends AbstractSinglePropertyField<MonthPicker, YearMo
   /**
    * Returns whether the month picker overlay is currently open.
    * <p>
-   * This property is synchronized from the client when the {@code opened-changed} event occurs.
+   * This property is synchronized from the client when the {@code vcf-month-picker-opened-changed} event occurs.
    *
    * @return {@code true} if open, {@code false} otherwise
    */
-  @Synchronize(property = "opened", value = "opened-changed")
+  @Synchronize(property = "opened", value = "vcf-month-picker-opened-changed")
   public boolean isOpened() {
     return getElement().getProperty("opened", false);
   }
@@ -361,7 +361,7 @@ public class MonthPicker extends AbstractSinglePropertyField<MonthPicker, YearMo
   /**
    * Event fired when the opened state of the overlay changes.
    */
-  @DomEvent("opened-changed")
+  @DomEvent("vcf-month-picker-opened-changed")
   public static class OpenedChangeEvent extends ComponentEvent<MonthPicker> {
     private final boolean opened;
 
@@ -376,7 +376,7 @@ public class MonthPicker extends AbstractSinglePropertyField<MonthPicker, YearMo
   }
 
   /**
-   * Adds a listener for {@code opened-changed} events triggered when the overlay is opened or closed.
+   * Adds a listener for {@code vcf-month-picker-opened-changed} events triggered when the overlay is opened or closed.
    *
    * @param listener the event listener
    * @return a {@link Registration} for removing the listener


### PR DESCRIPTION
Added new i18n setting for short month names. These will be used, when "MMM" patterns are added to the formats.

Also extended demos for 2-digit years, short and full month names.

Requires https://github.com/vaadin-component-factory/vcf-month-picker/pull/4 to be merged. Also the referenced npm versions need to be updated.  