### PR TITLE
Text field to light dom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.vaadin.addons.componentfactory</groupId>
     <artifactId>vcf-month-picker-flow-parent</artifactId>
-    <version>1.1.0</version>
+    <version>2.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Month Picker Parent</name>
 

--- a/vcf-month-picker-flow-demo/pom.xml
+++ b/vcf-month-picker-flow-demo/pom.xml
@@ -9,7 +9,7 @@
     <packaging>war</packaging>
     <name>Month Picker Add-on Demo</name>
 
-    <version>1.1.0</version>
+    <version>2.0.0-SNAPSHOT</version>
     <inceptionYear>2025</inceptionYear>
     <organization>
         <name>Vaadin Ltd</name>

--- a/vcf-month-picker-flow/pom.xml
+++ b/vcf-month-picker-flow/pom.xml
@@ -10,7 +10,7 @@
 
     <name>Month Picker Add-on</name>
 
-    <version>1.1.0</version>
+    <version>2.0.0-SNAPSHOT</version>
     <inceptionYear>2025</inceptionYear>
     <organization>
         <name>Vaadin Ltd</name>

--- a/vcf-month-picker-flow/src/main/java/org/vaadin/addons/componentfactory/monthpicker/MonthPicker.java
+++ b/vcf-month-picker-flow/src/main/java/org/vaadin/addons/componentfactory/monthpicker/MonthPicker.java
@@ -51,7 +51,7 @@ import jakarta.annotation.Nullable;
  */
 @SuppressWarnings("serial")
 @Tag("vcf-month-picker")
-@NpmPackage(value = "@vaadin-component-factory/vcf-month-picker", version = "1.1.0")
+@NpmPackage(value = "@vaadin-component-factory/vcf-month-picker", version = "2.0.0")
 @JsModule("@vaadin-component-factory/vcf-month-picker/dist/src/vcf-month-picker.js")
 public class MonthPicker extends AbstractSinglePropertyField<MonthPicker, YearMonth>
     implements HasLabel, HasAutoOpen, HasClearButton, HasPlaceholder, HasHelper, HasValidation,


### PR DESCRIPTION
This PR updates web-component version to [2.0.0](https://github.com/vaadin-component-factory/vcf-month-picker/releases/tag/2.0.0). Changes in that version are meant to expose the base text field to the light DOM. This adjustment was requested -as part of a suppport request- to enhance accessibility & styling.

As the updates in the web-component are considered a breaking change the version of the component was updated to 2.0.0-SNAPSHOT.